### PR TITLE
Minor memory issues

### DIFF
--- a/FedemDB.C
+++ b/FedemDB.C
@@ -312,6 +312,7 @@ DLLexport(void) FmClose (bool removeSingletons = false)
   cleanUpMemory();
   if (removeSingletons)
   {
+    FmDB::removeInstances();
     FFaCmdLineArg::removeInstance();
     FFaUserFuncPlugin::removeInstance();
     FiUserElmPlugin::removeInstance();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,12 @@ if ( Qt4_FOUND )
 elseif ( LINUX )
   string ( APPEND CMAKE_CXX_FLAGS " -DFT_HAS_DIRENT" )
 endif ( Qt4_FOUND )
+if ( USE_MEMPOOL )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_MEMPOOL" )
+endif ( USE_MEMPOOL )
+if ( USE_VISUALS )
+  string ( APPEND CMAKE_CXX_FLAGS " -DFT_USE_VISUALS" )
+endif ( USE_VISUALS )
 
 
 # Add some unit tests using gtest (executed via ctest)

--- a/test/test_FmPart.C
+++ b/test/test_FmPart.C
@@ -54,6 +54,8 @@ int main (int argc, char** argv)
   // Invoke the google test driver
   int status = RUN_ALL_TESTS();
 
+  // Clean up heap memory
+  FmDB::removeInstances();
   FFaCmdLineArg::removeInstance();
   return status;
 }

--- a/vpmDB/FmDB.C
+++ b/vpmDB/FmDB.C
@@ -85,6 +85,7 @@
 #include "vpmDB/FmUserDefinedElement.H"
 #include "vpmDB/FmModelExpOptions.H"
 #include "vpmDB/Icons/FmIconPixmaps.H"
+#include "vpmDB/FmModelMemberConnector.H"
 #ifdef USE_INVENTOR
 #include "vpmDisplay/FdDB.H"
 #endif
@@ -397,6 +398,28 @@ void FmDB::init()
 
   // Initialize the version number of current executable
   ourCurrentFedemVersion.parseLine(FedemAdmin::getVersion());
+}
+
+
+/*!
+  This method cleans up the heap-allocated singelton objects
+  in FmDB which are not related to a mechanism model as such.
+  Used mainly in test programs to verify no memory leaks, etc.
+*/
+
+void FmDB::removeInstances()
+{
+  itsEarthLink->erase();
+  itsEarthLink = NULL;
+
+  delete itsFuncTree;
+  itsFuncTree = NULL;
+
+  for (FmHeadMap::value_type& head : ourHeadMap)
+    delete head.second;
+  ourHeadMap.clear();
+
+  FmSignalConnector::removeInstance();
 }
 
 

--- a/vpmDB/FmDB.H
+++ b/vpmDB/FmDB.H
@@ -86,6 +86,7 @@ class FmDB
 
 public:
   static void init();
+  static void removeInstances();
 
   static void initHeadMap(FmHeadMap& headMap, FmFuncTree*& funcTree);
   static void sortHeadMap(const FmHeadMap& headMap, FmHeadMap& sortedHeadMap,


### PR DESCRIPTION
This consumes SAP/fedem-foundation#1 which then necessitates the setting of the compiler flag for the unit test program to avoid memory corruption. Also adding a method in FmDB to clean up all static heap-allocated objects, to verify there are no other memory leaks.